### PR TITLE
feat(index): Add details section

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'activeadmin', github: 'activeadmin'
 gem 'newrelic_rpm'
 gem 'bugsnag'
 
-gem 'bootstrap-sass', '~> 3.2.0'
+gem 'bootstrap-sass', '~> 3.3.0'
 gem 'autoprefixer-rails'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     autoprefixer-rails (3.1.0.20140911)
       execjs
     bcrypt (3.1.10)
-    bootstrap-sass (3.2.0.2)
+    bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     bourbon (3.2.4)
       sass (~> 3.2)
@@ -215,7 +215,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   autoprefixer-rails
-  bootstrap-sass (~> 3.2.0)
+  bootstrap-sass (~> 3.3.0)
   bugsnag
   coffee-rails (~> 4.0.0)
   devise

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -9,6 +9,22 @@
 
 .pages-footer { color: #aaa; }
 
+// details-section
+.details-section {
+  display: inline-block;
+  width: 100%;
+  position: relative;
+  margin-bottom: 1px;
+  padding: 16px;
+  background: white;
+}
+
+.embed-responsive {
+  &.embed-responsive-map {
+    padding-bottom: 40%;
+  }
+}
+
 
 // link
 
@@ -73,4 +89,9 @@
     background: #ffdfd4;
     content: '';
   }
+}
+
+// utility classes
+.mb0 {
+  margin-bottom: 0px !important;
 }

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -2,7 +2,7 @@
 
 .pages-header {
   height: 75px;
-  background: white;
+  background: #ffffff;
 }
 
 .pages-body { }
@@ -11,12 +11,12 @@
 
 // details-section
 .details-section {
+  background: #ffffff;
   display: inline-block;
-  width: 100%;
-  position: relative;
   margin-bottom: 1px;
   padding: 16px;
-  background: white;
+  position: relative;
+  width: 100%;
 }
 
 .embed-responsive {
@@ -93,5 +93,5 @@
 
 // utility classes
 .mb0 {
-  margin-bottom: 0px !important;
+  margin-bottom: 0 !important;
 }

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,16 +1,43 @@
 <div class="row">
   <div class="col-sm-12">
     <section>
-      <h5 class="event-heading">Next Event</h5>
-      <%= render @page.next_event %>
+      <div class="row">
+        <h5 class="event-heading">Next Event</h5>
+        <%= render @page.next_event %>
+      </div>
     </section>
 
     <section>
-      <h5 class="event-heading">Recent Events</h5>
-      <ul class="events list">
-        <%= render partial: 'events/item', collection: @page.past_events %>
-      </ul>
-      <a style="float: right" href="http://www.meetup.com/Full-Stack-North-County/">More events</a>
+      <div class="row">
+        <h5 class="event-heading">Recent Events</h5>
+        <ul class="events list">
+          <%= render partial: 'events/item', collection: @page.past_events %>
+        </ul>
+        <a style="float: right" href="http://www.meetup.com/Full-Stack-North-County/">More events</a>
+      </div>
+    </section>
+
+    <section>
+      <div class="row">
+        <h5 class="event-heading">Meetup Details</h5>
+        <div class="details-section">
+          <div class="col-sm-4">
+            <p>We meet on the second Thursday of every month at 7:00 PM. Drinks and snacks are provided!</p>
+            <p>After the talks, you're welcome to make use of our desk space and team rooms while you're here, so feel free to bring a project to hack.</p>
+            <p>The monthly meetup is held at the Planning Center Online offices:</p>
+            <address class="col-sm-offset-1">
+              <h5 class="mb0">Planning Center Online</h5>
+              2790 Gateway Road<br />
+              Carlsbad, CA 92009
+            </address>
+          </div>
+          <div class="col-sm-8">
+            <div class="embed-responsive embed-responsive-map">
+              <iframe class="embed-responsive-item" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3341.262944087737!2d-117.24692200000005!3d33.128456!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x80dc74bf20ebfbf9%3A0x692a343a8ecce621!2s2790+Gateway+Rd%2C+Carlsbad%2C+CA+92009!5e0!3m2!1sen!2sus!4v1423853026783"></iframe>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
   </div>
 </div>


### PR DESCRIPTION
This PR adds a "Meetup Details" section to the index page. The section includes meeting times (second Thursday at 7pm), the address for the office, and an embedded google map so that users can easily use google maps to get directions to the office.

I wasn't really sure how to style the text for the details section. Blue might feel more consistent with the rest of the text on the page but the blue comes from the text being in an `<a>` so I didn't want to make non-`<a>` text blue. 

I also updated the bootstrap-sass gem. I did that because I was having problems with `.responsive-embed`. The issue I was having turned out to be unrelated but I figured I might as well leave the updated gem in there since it didn't look like it broke anything. 

Let me know what you think. 